### PR TITLE
adding documentation to RSTree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ jobs:
     - name: Checkout Project
       uses: actions/checkout@v1
 
-    - name: Switch to Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.app
+        #- name: Switch to Xcode 12
+        #  run: sudo xcode-select -s /Applications/Xcode_12.app
 
     - name: Run Build
       run: swift build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .build/
 build/
 DerivedData/
+Sources/RSTree/Documentation.docc/.docc-build/
 
 ## Various settings
 *.pbxuser

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
             type: .dynamic,
             targets: ["RSTree"]),
     ],
+    // dependencies = [
+    //     .package(url: "https://github.com/apple/swift-docc-plugin", branch: "main"),
+    // ]
     targets: [
         .target(
             name: "RSTree",

--- a/Sources/RSTree/Documentation.docc/Documentation.md
+++ b/Sources/RSTree/Documentation.docc/Documentation.md
@@ -1,0 +1,31 @@
+# ``RSTree``
+
+The data structures to assemble and present a tree of objects as an outline.
+
+## Overview
+
+RSTree provides the data structures and methods to build, collect, and selectively display a tree of objects as a disclosable outline view.
+[NetNewsWire](https://netnewswire.com) uses the `RSTree` library within the [sidebar view controller](https://github.com/Ranchero-Software/NetNewsWire/blob/main/Mac/MainWindow/Sidebar/SidebarViewController.swift) to present a collection of feeds and related information, organized by the user.
+
+The tree data structure is represented by a hierarchy of ``RSTree/Node`` instances that you create, each of which represent another `Hashable` object.
+The ``RSTree/Node`` makes it easier to assemble a tree of ordered identities for objects without having to add properties directly to those objects.
+An individual tree is represented by the ``RSTree/TreeController``, which provides generalized access to the nodes within the tree, and a customizable response for child nodes using ``RSTree/TreeControllerDelegate``.
+This customized response allows NetNewsWire to provide virtual collections (the Smart Feeds feature) as a lens into a subset of the objects contained within the tree. 
+
+The library includes an extension on `NSOutlineView` to search for an relevant an object within the tree data structure, disclose the path to the element, and make it the selected element within the Outline View.
+`revealAndSelectNodeAtPath` takes a ``RSTree/NodePath`` as a parameter. 
+`revealAndSelectRepresentedObject` searches for a object within a given ``RSTree/TreeController``.
+
+
+## Topics
+
+### Creating a Tree of Nodes 
+
+- ``RSTree/Node``
+- ``RSTree/NodePath``
+- ``RSTree/NodeVisitBlock``
+
+### Displaying the Nodes
+
+- ``RSTree/TreeController``
+- ``RSTree/TreeControllerDelegate``

--- a/Sources/RSTree/Documentation.docc/RSTree_Node.md
+++ b/Sources/RSTree/Documentation.docc/RSTree_Node.md
@@ -1,0 +1,51 @@
+# ``RSTree/Node``
+
+## Topics
+
+### Creating Nodes
+
+- ``RSTree/Node/init(representedObject:parent:)``
+- ``RSTree/Node/genericRootNode()``
+- ``RSTree/Node/existingOrNewChildNode(with:)``
+- ``RSTree/Node/createChildNode(_:)``
+
+### Comparing Nodes
+
+- ``RSTree/Node/!=(_:_:)``
+- ``RSTree/Node/==(_:_:)``
+- ``RSTree/Node/hash(into:)``
+
+### Inspecting Nodes
+
+- ``RSTree/Node/representedObject``
+- ``RSTree/Node/isRoot``
+- ``RSTree/Node/parent``
+- ``RSTree/Node/childNodes``
+- ``RSTree/Node/numberOfChildNodes``
+- ``RSTree/Node/canHaveChildNodes``
+- ``RSTree/Node/isLeaf``
+- ``RSTree/Node/level``
+- ``RSTree/Node/indexPath``
+- ``RSTree/Node/uniqueID``
+- ``RSTree/Node/isGroupItem``
+
+### Searching for Descendant Nodes
+
+- ``RSTree/Node/childNodeRepresentingObject(_:)``
+- ``RSTree/Node/childAtIndex(_:)``
+- ``RSTree/Node/indexOfChild(_:)``
+- ``RSTree/Node/descendantNode(where:)``
+- ``RSTree/Node/descendantNodeRepresentingObject(_:)``
+
+### Searching for Ancestor Nodes
+
+- ``RSTree/Node/hasAncestor(in:)``
+- ``RSTree/Node/isAncestor(of:)``
+
+### Grouping Nodes
+
+- ``RSTree/Node/nodesOrganizedByParent(_:)``
+- ``RSTree/Node/indexSetsGroupedByParent(_:)``
+
+
+

--- a/Sources/RSTree/Documentation.docc/RSTree_NodePath.md
+++ b/Sources/RSTree/Documentation.docc/RSTree_NodePath.md
@@ -1,0 +1,8 @@
+# ``RSTree/NodePath``
+
+## Topics
+
+### Creating a Node Path
+
+- ``RSTree/NodePath/init(node:)``
+- ``RSTree/NodePath/init(representedObject:treeController:)``

--- a/Sources/RSTree/Documentation.docc/RSTree_Node_NotEquals.md
+++ b/Sources/RSTree/Documentation.docc/RSTree_Node_NotEquals.md
@@ -1,0 +1,7 @@
+# ``RSTree/Node/!=(_:_:)``
+
+Returns a Boolean value indicating whether two nodes are not equal.
+
+- Parameters:
+  - lhs: The first node to compare.
+  - rhs: The second node to compare.

--- a/Sources/RSTree/Documentation.docc/RSTree_TreeController.md
+++ b/Sources/RSTree/Documentation.docc/RSTree_TreeController.md
@@ -1,0 +1,27 @@
+# ``RSTree/TreeController``
+
+## Topics
+
+### Creating a Tree Controller
+
+- ``RSTree/TreeController/init(delegate:)``
+- ``RSTree/TreeController/init(delegate:rootNode:)``
+
+### Inspecting the Tree Controller
+
+- ``RSTree/TreeController/rootNode``
+
+### Searching for Nodes
+
+- ``RSTree/TreeController/nodeInArrayRepresentingObject(nodes:representedObject:recurse:)``
+- ``RSTree/TreeController/nodeInTreeRepresentingObject(_:)``
+- ``RSTree/TreeController/normalizedSelectedNodes(_:)``
+
+### Operating on Each Node in the Tree
+
+- ``RSTree/TreeController/visitNodes(_:)``
+
+### Organizing the Nodes Within the Tree
+
+- ``RSTree/TreeController/rebuild()``
+

--- a/Sources/RSTree/Documentation.docc/RSTree_TreeControllerDelegate.md
+++ b/Sources/RSTree/Documentation.docc/RSTree_TreeControllerDelegate.md
@@ -1,0 +1,7 @@
+# ``RSTree/TreeControllerDelegate``
+
+## Topics
+
+### Specializing Found Child Nodes 
+
+- ``RSTree/TreeControllerDelegate/treeController(treeController:childNodesFor:)``

--- a/Sources/RSTree/Node.swift
+++ b/Sources/RSTree/Node.swift
@@ -10,27 +10,40 @@ import Foundation
 
 // Main thread only.
 
+/// A reference to a type that you wish to display within a tree-like context, such as a disclosable outline view.
+///
+/// The class includes additional information about the tree hierarchy of the nodes in order to display them as an increasingly disclosed outline view.
+/// Call the methods on this class from the main thread.
 public final class Node: Hashable {
-	
-	public weak var parent: Node?
-	public let representedObject: AnyObject
-	public var canHaveChildNodes = false
-	public var isGroupItem = false
-	public var childNodes = [Node]()
+    
+    /// The parent of this node, if it has one.
+    public weak var parent: Node?
+    /// The object that this node represents.
+    public let representedObject: AnyObject
+    /// A Boolean value that indicates whether the node is allowed to have child nodes.
+    public var canHaveChildNodes = false
+    /// A Boolean value that indicates the node represents a group of items.
+    public var isGroupItem = false
+    /// The list of child nodes.
+    public var childNodes = [Node]()
+    /// The unique identifier of the node.
 	public let uniqueID: Int
 	private static var incrementingID = 0
-
+    
+    /// A Boolean value that indicates whether this node is the root of a tree of nodes.
 	public var isRoot: Bool {
 		if let _ = parent {
 			return false
 		}
 		return true
 	}
-	
+    
+    /// The number of children for the node.
 	public var numberOfChildNodes: Int {
 		return childNodes.count
 	}
-	
+    
+    /// The index path from the root of a tree to this node.
 	public var indexPath: IndexPath {
 		if let parent = parent {
 			let parentPath = parent.indexPath
@@ -41,18 +54,24 @@ public final class Node: Hashable {
 		}
 		return IndexPath(index: 0) //root node
 	}
-	
+    
+    /// The depth of the node within the tree.
 	public var level: Int {
 		if let parent = parent {
 			return parent.level + 1
 		}
 		return 0
 	}
-	
+    
+    /// A Boolean value that indicates if the node has no children.
 	public var isLeaf: Bool {
 		return numberOfChildNodes < 1
 	}
-	
+    
+    /// Creates a new node for the represented object you provide.
+    /// - Parameters:
+    ///   - representedObject: The object that this node represents within a tree.
+    ///   - parent: The parent node if it has one; otherwise, `nil`.
 	public init(representedObject: AnyObject, parent: Node?) {
 		
 		precondition(Thread.isMainThread)
@@ -63,14 +82,21 @@ public final class Node: Hashable {
 		self.uniqueID = Node.incrementingID
 		Node.incrementingID += 1
 	}
-	
+    
+    /// Creates a generic root node which doesn't relate to any specific object.
+    ///
+    /// The ``representedObject`` for this node is an internal empty class, and doesn't represent anything specific.
+    /// - Returns: The root node for a tree.
 	public class func genericRootNode() -> Node {
 		
 		let node = Node(representedObject: TopLevelRepresentedObject(), parent: nil)
 		node.canHaveChildNodes = true
 		return node
 	}
-
+    
+    /// Searches for a child node that matches the object you provide, creating a new child node if the object doesn't already exist as a child.
+    /// - Parameter representedObject: The object the node represents.
+    /// - Returns: The node for the object you provided.
 	public func existingOrNewChildNode(with representedObject: AnyObject) -> Node {
 
 		if let node = childNodeRepresentingObject(representedObject) {
@@ -78,13 +104,19 @@ public final class Node: Hashable {
 		}
 		return createChildNode(representedObject)
 	}
-
+    
+    /// Creates a new, disconnected, node for the object you provide.
+    /// - Parameter representedObject: The object the node represents.
+    /// - Returns: The node for the object you provided.
 	public func createChildNode(_ representedObject: AnyObject) -> Node {
 
 		// Just creates — doesn’t add it.
 		return Node(representedObject: representedObject, parent: self)
 	}
-
+    
+    /// Returns the child node at the index location you provide.
+    /// - Parameter index: The index location of the child nodes.
+    /// - Returns: The node, or `nil` if the index is outside the range of the child nodes.
 	public func childAtIndex(_ index: Int) -> Node? {
 		
 		if index >= childNodes.count || index < 0 {
@@ -92,26 +124,41 @@ public final class Node: Hashable {
 		}
 		return childNodes[index]
 	}
-
+    
+    /// Returns the index location of the node you provide.
+    /// - Parameter node: The child node.
+    /// - Returns: The index within the list of child nodes, or `nil` if the node isn't in the list of child nodes.
 	public func indexOfChild(_ node: Node) -> Int? {
 		
 		return childNodes.firstIndex{ (oneChildNode) -> Bool in
 			oneChildNode === node
 		}
 	}
-	
+    
+    /// Searches the children of this node to find the node representing the object you provide.
+    /// - Parameter obj: The represented object.
+    /// - Returns: The node that represents this object in the tree, or `nil` if it doesn't exist.
 	public func childNodeRepresentingObject(_ obj: AnyObject) -> Node? {
 		return findNodeRepresentingObject(obj, recursively: false)
 	}
 
+    /// Recursively searches from this node through the tree to find the node representing the object you provide.
+    /// - Parameter obj: The represented object.
+    /// - Returns: The node that represents this object in the tree, or `nil` if it doesn't exist.
 	public func descendantNodeRepresentingObject(_ obj: AnyObject) -> Node? {
 		return findNodeRepresentingObject(obj, recursively: true)
 	}
-
+    
+    /// Recursively searches for a node that matches closure you provide.
+    /// - Parameter test: A closure that evaluates the node for inclusion in a result.
+    /// - Returns: The descendant node that matched, or `nil` if no nodes matched.
 	public func descendantNode(where test: (Node) -> Bool) -> Node? {
 		return findNode(where: test, recursively: true)
 	}
-
+    
+    /// Returns a Boolean value that indicates if this node has one of the nodes you provide as a parent or ancestor.
+    /// - Parameter nodes: The list of nodes to evaluate as potential ancestors.
+    /// - Returns: `true` if the node is a descendant of one of the nodes from the provided list.
 	public func hasAncestor(in nodes: [Node]) -> Bool {
 
 		for node in nodes {
@@ -121,7 +168,10 @@ public final class Node: Hashable {
 		}
 		return false
 	}
-
+    
+    /// Returns a Boolean value that indicates if the node you provide is an ancestor within the tree.
+    /// - Parameter node: The node to compare as a potential ancestor.
+    /// - Returns: `true` if the node is a parent or ancestor, otherwise `false`.
 	public func isAncestor(of node: Node) -> Bool {
 
 		if node == self {
@@ -139,13 +189,18 @@ public final class Node: Hashable {
 			nomad = parent
 		}
 	}
-
+    
+    /// Returns a dictionary of the nodes you provide, organized by common parent nodes.
+    /// - Parameter nodes: The nodes to organize by parent.
 	public class func nodesOrganizedByParent(_ nodes: [Node]) -> [Node: [Node]] {
 
 		let nodesWithParents = nodes.filter { $0.parent != nil }
 		return Dictionary(grouping: nodesWithParents, by: { $0.parent! })
 	}
-
+    
+    /// Returns an index set of the nodes you provide, organized by common parent nodes.
+    /// - Parameter nodes: The nodes to organize by parent.
+    /// - Returns: <#description#>
 	public class func indexSetsGroupedByParent(_ nodes: [Node]) -> [Node: IndexSet] {
 
 		let d = nodesOrganizedByParent(nodes)
@@ -170,13 +225,19 @@ public final class Node: Hashable {
 	}
 
 	// MARK: - Hashable
-
+    
+    /// Hashes the essential components of this node by feeding them into the given hasher.
+    /// - Parameter hasher: The hasher to use when combining the components of this instance.
 	public func hash(into hasher: inout Hasher) {
 		hasher.combine(uniqueID)
 	}
 
 	// MARK: - Equatable
-
+    
+    /// Returns a Boolean value indicating whether two nodes are equal.
+    /// - Parameters:
+    ///   - lhs: The first node to compare.
+    ///   - rhs: The second node to compare.
 	public class func ==(lhs: Node, rhs: Node) -> Bool {
 		return lhs === rhs
 	}

--- a/Sources/RSTree/NodePath.swift
+++ b/Sources/RSTree/NodePath.swift
@@ -8,10 +8,14 @@
 
 import Foundation
 
+/// An array of nodes that represents the path through a tree structure to a specific item.
 public struct NodePath {
-
+    
+    /// The list of nodes that make up the path
 	let components: [Node]
-
+    
+    /// Creates a new node path from the node you provide.
+    /// - Parameter node: The node to identify with a node path.
 	public init(node: Node) {
 
 		var tempArray = [node]
@@ -29,7 +33,14 @@ public struct NodePath {
 
 		self.components = tempArray.reversed()
 	}
-
+    
+    /// Creates a node path by searching through the tree of nodes within the tree controller you provide.
+    ///
+    /// - Parameters:
+    ///   - representedObject: The represented object to find within the nodes of the tree.
+    ///   - treeController: The tree controller that represents the tree of nodes to search.
+    ///
+    ///  Returns `nil` if the tree doesn't have the represented object within it's nodes, 
 	public init?(representedObject: AnyObject, treeController: TreeController) {
 
 		if let node = treeController.nodeInTreeRepresentingObject(representedObject) {

--- a/Sources/RSTree/TreeController.swift
+++ b/Sources/RSTree/TreeController.swift
@@ -8,43 +8,77 @@
 
 import Foundation
 
+/// A type that provides a searchable index into a set of nodes.
+///
+/// Search through the nodes for which the delegate contains references.
+/// You can use this to change the representation based on the kind of instance included within the node's ``RSTree/Node/representedObject`` property.
+/// For example, in NetNewsWire the  [`WebFeedTreeControllerDelegate`](https://github.com/Ranchero-Software/NetNewsWire/blob/main/Shared/Tree/WebFeedTreeControllerDelegate.swift#L27-L39) returns a different set of child nodes if the provided node is a root node, a child node, or a set of filtered nodes.
 public protocol TreeControllerDelegate: AnyObject {
-	
+    
+    /// Returns a list of child nodes for the reference to the node you provide.
+    /// - Parameters:
+    ///   - treeController: The tree controller associated with this set of nodes.
+    ///   - childNodesFor: The set of child nodes that correspond to the node you provide.
+    /// - Returns: A list of relevant child nodes, or nil if the node doesn't have any children.
 	func treeController(treeController: TreeController, childNodesFor: Node) -> [Node]?
 }
 
+
+/// A type that supports the visitor pattern to recursively visit nodes within a tree of nodes..
 public typealias NodeVisitBlock = (_ : Node) -> Void
 
+/// A controller used by the outlive view extension to support searching for and displaying nodes.
 public final class TreeController {
 
-	private weak var delegate: TreeControllerDelegate?
+    private weak var delegate: TreeControllerDelegate?
+    /// The root node for the tree.
 	public let rootNode: Node
-
+    
+    /// Creates a new tree controller with the tree controller delegate and root node that you provide.
+    /// - Parameters:
+    ///   - delegate: The delegate for the tree controller.
+    ///   - rootNode: The root node for the tree.
 	public init(delegate: TreeControllerDelegate, rootNode: Node) {
 		
 		self.delegate = delegate
 		self.rootNode = rootNode
 		rebuild()
 	}
-
+    
+    /// Creates a new tree controller with the tree controller delegate that you provide.
+    /// - Parameter delegate: The delegate for the tree controller.
+    ///
+    /// The root node is generated automatically as a generic root node that doesn't represent any object.
 	public convenience init(delegate: TreeControllerDelegate) {
 		
 		self.init(delegate: delegate, rootNode: Node.genericRootNode())
 	}
 	
-	@discardableResult
+    /// Iterates through child nodes, re-ordering child nodes at each level.
+    /// - Returns: `true` if the rebuild changed the ordering of any nodes.
+    @discardableResult
 	public func rebuild() -> Bool {
 
 		// Rebuild and re-sort. Return true if any changes in the entire tree.
 		
 		return rebuildChildNodes(node: rootNode)
 	}
-	
+    
+    /// Iterates through all nodes in tree applying the closure you provide to each.
+    /// - Parameter visitBlock: A closure that this class invokes with each node in the tree.
+    ///
+    /// Use this function to implement a visitor pattern across the nodes within the tree.
 	public func visitNodes(_ visitBlock: NodeVisitBlock) {
 		
 		visitNode(rootNode, visitBlock)
 	}
-	
+    
+    /// Returns the node from the list you provide that matches the represented object.
+    /// - Parameters:
+    ///   - nodes: The nodes to compare.
+    ///   - representedObject: The represented object to find within the set of nodes.
+    ///   - recurse: A Boolean value that indicates whether the children of the nodes should be searched for the represented object.
+    /// - Returns: The node matching the represented object, or `nil` if not found.
 	public func nodeInArrayRepresentingObject(nodes: [Node], representedObject: AnyObject, recurse: Bool = false) -> Node? {
 		
 		for oneNode in nodes {
@@ -62,12 +96,18 @@ public final class TreeController {
 		}
 		return nil
 	}
-
+    
+    /// Recursively searches through the tree to find the node that represents the object that you provide.
+    /// - Parameter representedObject: The represented object to find within the tree of nodes.
+    /// - Returns: The node for the object, or `nil` if it wasn't found.
 	public func nodeInTreeRepresentingObject(_ representedObject: AnyObject) -> Node? {
 
 		return nodeInArrayRepresentingObject(nodes: [rootNode], representedObject: representedObject, recurse: true)
 	}
-
+    
+    /// Returns a normalized list of nodes that removes any child nodes from parents that are in the list you provide.
+    /// - Parameter nodes: The nodes to normalize.
+    /// - Returns: A list of nodes without any nodes that are children of other nodes in the list.
 	public func normalizedSelectedNodes(_ nodes: [Node]) -> [Node] {
 
 		// An array of nodes might include a leaf node and its parent. Remove the leaf node.

--- a/docbuild.bash
+++ b/docbuild.bash
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+echo "Make sure you've rebased over the current HEAD branch:"
+echo "git rebase -i origin/main docs"
+
+set -e  # exit on a non-zero return code from a command
+set -x  # print a trace of commands as they execute
+
+# rm -rf .build
+# mkdir -p .build/symbol-graphs
+
+# $(xcrun --find swift) build --target RSTree \
+#     -Xswiftc -emit-symbol-graph \
+#     -Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
+
+# Enables deterministic output
+# - useful when you're committing the results to host on github pages
+export DOCC_JSON_PRETTYPRINT=YES
+
+#$(xcrun --find docc) convert Sources/RSTree/Documentation.docc \
+#    --output-path ./docs \
+#    --fallback-display-name RSTree \
+#    --fallback-bundle-identifier com.github.heckj.RSTree \
+#    --fallback-bundle-version 0.1.0 \
+#    --additional-symbol-graph-dir .build/symbol-graphs \
+#    --emit-digest \
+#    --transform-for-static-hosting \
+#    --hosting-base-path 'RSTree'
+
+# Add the following as a dependency into your Package.swift
+#
+# // Swift-DocC Plugin - swift 5.6 ONLY (GitHhub Actions on 1/29/2022 only supports to 5.5)
+#     dependencies: [
+#        .package(url: "https://github.com/apple/swift-docc-plugin", branch: "main"),
+#    ],
+# run:
+#   $(xcrun --find swift) package resolve
+#   $(xcrun --find swift) build
+
+
+# Swift package plugin for hosted content:
+#
+$(xcrun --find swift) package \
+    --allow-writing-to-directory ./docs \
+    generate-documentation \
+    --target RSTree \
+    --output-path ./docs \
+    --emit-digest \
+    --disable-indexing \
+    --transform-for-static-hosting \
+    --hosting-base-path 'RSTree'
+
+# Generate a list of all the identifiers to assist in DocC curation
+#
+
+# cat docs/linkable-entities.json | jq '.[].referenceURL' -r > all_identifiers.txt
+# sort all_identifiers.txt \
+#     | sed -e 's/doc:\/\/RSTree\/documentation\///g' \
+#     | sed -e 's/^/- ``/g' \
+#     | sed -e 's/$/``/g' > all_symbols.txt
+
+echo "Page will be available at https://heckj.github.io/RSTree/documentation/rstree/"
+
+# xcodebuild docbuild -scheme RSTree -destination platform=macOS
+#
+# generated RSTree.doccarchive located in ~/Library/Developer/DerivedData/RSTree*/Build/Products/Debug
+
+# Example from swift forum post to show building docs for an iOS Xcode project:
+# xcodebuild docbuild -scheme ExampleDocC \
+#     -destination generic/platform=iOS \
+#     OTHER_DOCC_FLAGS="--transform-for-static-hosting --hosting-base-path ExampleDocC --output-path docs"

--- a/docpreview.bash
+++ b/docpreview.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e  # exit on a non-zero return code from a command
+set -x  # print a trace of commands as they execute
+
+rm -rf .build
+mkdir -p .build/symbol-graphs
+
+$(xcrun --find swift) build --target RSTree \
+    -Xswiftc -emit-symbol-graph \
+    -Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
+
+$(xcrun --find docc) convert Sources/RSTree/Documentation.docc \
+    --analyze \
+    --fallback-display-name RSTree \
+    --fallback-bundle-identifier com.github.heckj.RSTree \
+    --fallback-bundle-version 0.1.0 \
+    --additional-symbol-graph-dir .build/symbol-graphs \
+    --experimental-documentation-coverage \
+    --level brief
+
+$(xcrun --find docc) preview Sources/RSTree/Documentation.docc \
+    --fallback-display-name RSTree \
+    --fallback-bundle-identifier com.github.heckj.RSTree \
+    --fallback-bundle-version 0.1.0 \
+    --additional-symbol-graph-dir .build/symbol-graphs

--- a/docreport.bash
+++ b/docreport.bash
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e  # exit on a non-zero return code from a command
+set -x  # print a trace of commands as they execute
+
+rm -rf .build
+mkdir -p .build/symbol-graphs
+
+$(xcrun --find swift) build --target RSTree \
+    -Xswiftc -emit-symbol-graph \
+    -Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
+
+$(xcrun --find docc) convert Sources/RSTree/Documentation.docc \
+    --analyze \
+    --fallback-display-name RSTree \
+    --fallback-bundle-identifier com.github.heckj.RSTree \
+    --fallback-bundle-version 0.1.0 \
+    --additional-symbol-graph-dir .build/symbol-graphs \
+    --experimental-documentation-coverage \
+    --level brief
+
+# Generating a parsable coverage file with `docbuild`:
+# xcodebuild docbuild -scheme RSTree \
+#     -derivedDataPath ~/Desktop/RSTreeBuild \
+#     -destination platform=macOS \
+#     OTHER_DOCC_FLAGS="--experimental-documentation-coverage --level brief”
+# Coverage file in JSON format at
+# ~/Desktop/RSTreeBuild/Build/Products/Debug/RSTree.doccarchive/documentation-coverage.json


### PR DESCRIPTION
content created for DocC, and added scripts to generate locally. I specifically left the swift version at 5.3, which means that locally generated documentation won't be easily generated and use the DocC catalog that I've included. However, any project using swift 5.5 or later and bringing this in as a dependency will be able to take advantage of the documentation comments.

The PR also includes 3 convenience scripts that I generated as part of the TrySwift! DocC workshop that seemed useful to go ahead and include, but aren't critical to leveraging these updates.

I am hosting the content for this library in my own forked repo, which can make the content easier to review:
- https://heckj.github.io/RSTree/documentation/rstree/